### PR TITLE
add `docker-compose build`

### DIFF
--- a/launch_network.bash
+++ b/launch_network.bash
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+docker-compose build
 docker-compose up &
 echo 'Waiting for containers to start...'
 echo 'Starting core...'

--- a/launch_network_terminals.bash
+++ b/launch_network_terminals.bash
@@ -3,6 +3,7 @@
 # Alternatively: `docker-compose up -d`, but by launching it in the background, 
 # we capture the output on the current terminal & we can see the list of 
 # accounts that ganache creates (different every time)
+docker-compose build
 docker-compose up &
 xterm -geometry 90x20+20+20 -e "docker attach enigma_contract_1" &
 xterm -geometry 120x20+600+20 -e "docker attach enigma_core_1" &


### PR DESCRIPTION
When you follow readme for the first time you always get errors because its no way to build all images in 5s, its easy to skip this part of readme about the build (at last for me:D). In my opinion `docker-compose build` should be the first step in the script. docker will cache all layers so next time `build` command will only print information about used layers.